### PR TITLE
Add presigned URL endpoint for direct S3 image access

### DIFF
--- a/README.md
+++ b/README.md
@@ -192,6 +192,7 @@ https://your-domain.com/api/v1
 | `GET` | `/images/{id}/thumbnail` | Download thumbnail (150x150) | 100/min |
 | `GET` | `/images/{id}/preview` | Download preview (800x600) | 100/min |
 | `GET` | `/images/{id}/{resolution}` | Download custom resolution | 100/min |
+| `GET` | `/images/{id}/{resolution}/presigned-url` | Generate presigned URL for direct access | 50/min |
 | `GET` | `/health` | Health check | Unlimited |
 
 ### 1. Upload Image
@@ -257,7 +258,54 @@ GET /api/v1/images/{id}/info
 }
 ```
 
-### 3. Download Images
+### 3. Generate Presigned URL
+
+**Generate a temporary presigned URL for direct image access**
+
+```http
+GET /api/v1/images/{id}/{resolution}/presigned-url
+```
+
+**Path Parameters:**
+- `id` (string, required): Image UUID
+- `resolution` (string, required): Image size - `original`, `thumbnail`, `preview`, or custom resolution like `800x600`
+
+**Query Parameters:**
+- `expires_in` (integer, optional): Expiration time in seconds (default: 3600, max: 604800)
+
+**Response (200 OK):**
+```json
+{
+  "url": "https://bucket.s3.amazonaws.com/images/f47ac10b-58cc-4372-a567-0e02b2c3d479/thumbnail.jpg?X-Amz-Algorithm=...",
+  "expires_at": "2025-09-12T16:30:00Z",
+  "expires_in": 3600
+}
+```
+
+**cURL Examples:**
+
+Generate presigned URL for thumbnail (1 hour expiration):
+```bash
+curl "http://localhost:8080/api/v1/images/f47ac10b-58cc-4372-a567-0e02b2c3d479/thumbnail/presigned-url?expires_in=3600"
+```
+
+Generate presigned URL for custom resolution (24 hours expiration):
+```bash
+curl "http://localhost:8080/api/v1/images/f47ac10b-58cc-4372-a567-0e02b2c3d479/800x600/presigned-url?expires_in=86400"
+```
+
+Generate presigned URL for original image (default 1 hour expiration):
+```bash
+curl "http://localhost:8080/api/v1/images/f47ac10b-58cc-4372-a567-0e02b2c3d479/original/presigned-url"
+```
+
+**Use Cases:**
+- Client-side direct downloads without server proxy
+- Temporary sharing of images with expiration
+- Mobile app integration with direct S3 access
+- Reducing server bandwidth for large images
+
+### 4. Download Images
 
 **Download images in various resolutions**
 
@@ -279,7 +327,7 @@ GET /api/v1/images/{id}/800x600      # Custom WIDTHxHEIGHT
 - `Cache-Control`: `public, max-age=31536000, immutable`
 - Body: Binary image data
 
-### 4. Health Check
+### 5. Health Check
 
 **Check service health and dependencies**
 

--- a/internal/api/handlers/image.go
+++ b/internal/api/handlers/image.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 	"strconv"
 	"strings"
+	"time"
 
 	"resizr/internal/config"
 	"resizr/internal/models"
@@ -220,6 +221,122 @@ func (h *ImageHandler) DownloadCustomResolution(c *gin.Context) {
 	h.downloadImage(c, resolution)
 }
 
+// GeneratePresignedURL generates a pre-signed URL for image access
+// GET /api/v1/images/:id/:resolution/presigned-url
+func (h *ImageHandler) GeneratePresignedURL(c *gin.Context) {
+	ctx := c.Request.Context()
+	requestID := c.GetString("request_id")
+	imageID := c.Param("id")
+
+	// Get resolution from URL path
+	size := c.Param("resolution")
+
+	// Handle predefined resolutions by detecting URL patterns
+	fullPath := c.FullPath()
+	if strings.Contains(fullPath, "/original/presigned-url") {
+		size = "original"
+	} else if strings.Contains(fullPath, "/thumbnail/presigned-url") {
+		size = "thumbnail"
+	} else if strings.Contains(fullPath, "/preview/presigned-url") {
+		size = "preview"
+	}
+
+	// Get optional expires_in parameter (default: 1 hour)
+	expiresInParam := c.Query("expires_in")
+	expiresIn := 3600 // default: 1 hour
+	if expiresInParam != "" {
+		parsed, err := strconv.Atoi(expiresInParam)
+		if err != nil || parsed <= 0 {
+			c.JSON(http.StatusBadRequest, models.ErrorResponse{
+				Error:   "Invalid expires_in parameter",
+				Message: "expires_in must be a positive integer (seconds)",
+				Code:    http.StatusBadRequest,
+			})
+			return
+		}
+		expiresIn = parsed
+	}
+
+	// Validate maximum expiration (7 days)
+	maxExpiresIn := 7 * 24 * 3600 // 7 days in seconds
+	if expiresIn > maxExpiresIn {
+		c.JSON(http.StatusBadRequest, models.ErrorResponse{
+			Error:   "expires_in too large",
+			Message: fmt.Sprintf("Maximum expiration is %d seconds (7 days)", maxExpiresIn),
+			Code:    http.StatusBadRequest,
+		})
+		return
+	}
+
+	logger.DebugWithContext(ctx, "Generating presigned URL",
+		zap.String("image_id", imageID),
+		zap.String("size", size),
+		zap.Int("expires_in", expiresIn),
+		zap.String("request_id", requestID))
+
+	// Validate UUID format
+	if !h.isValidUUID(imageID) {
+		c.JSON(http.StatusBadRequest, models.ErrorResponse{
+			Error:   "Invalid image ID",
+			Message: "Image ID must be a valid UUID",
+			Code:    http.StatusBadRequest,
+		})
+		return
+	}
+
+	// Validate size format
+	if !h.isValidSize(size) {
+		c.JSON(http.StatusBadRequest, models.ErrorResponse{
+			Error:   "Invalid size parameter",
+			Message: "Size must be 'original', 'thumbnail', 'preview', or format WIDTHxHEIGHT (e.g., 800x600)",
+			Code:    http.StatusBadRequest,
+		})
+		return
+	}
+
+	// Get image metadata to verify image exists
+	metadata, err := h.imageService.GetMetadata(ctx, imageID)
+	if err != nil {
+		h.handleServiceError(c, err, requestID, "get metadata for presigned URL failed")
+		return
+	}
+
+	// Validate size exists (except for original)
+	if size != "original" && !metadata.HasResolution(size) {
+		c.JSON(http.StatusNotFound, models.ErrorResponse{
+			Error:   "Resolution not found",
+			Message: fmt.Sprintf("Resolution '%s' not available for this image", size),
+			Code:    http.StatusNotFound,
+		})
+		return
+	}
+
+	// Generate storage key and presigned URL
+	storageKey := metadata.GetStorageKey(size)
+	duration := time.Duration(expiresIn) * time.Second
+
+	presignedURL, err := h.imageService.GeneratePresignedURL(ctx, storageKey, duration)
+	if err != nil {
+		h.handleServiceError(c, err, requestID, "generate presigned URL failed")
+		return
+	}
+
+	expiresAt := time.Now().Add(duration)
+
+	logger.InfoWithContext(ctx, "Presigned URL generated successfully",
+		zap.String("image_id", imageID),
+		zap.String("size", size),
+		zap.Int("expires_in", expiresIn),
+		zap.Time("expires_at", expiresAt),
+		zap.String("request_id", requestID))
+
+	c.JSON(http.StatusOK, models.PresignedURLResponse{
+		URL:       presignedURL,
+		ExpiresAt: expiresAt,
+		ExpiresIn: expiresIn,
+	})
+}
+
 // downloadImage is a common handler for all image downloads
 func (h *ImageHandler) downloadImage(c *gin.Context, resolution string) {
 	ctx := c.Request.Context()
@@ -404,4 +521,14 @@ func (h *ImageHandler) isValidCustomResolution(resolution string) bool {
 	}
 
 	return true
+}
+
+func (h *ImageHandler) isValidSize(size string) bool {
+	// Check predefined sizes
+	if size == "original" || size == "thumbnail" || size == "preview" {
+		return true
+	}
+
+	// Check custom resolution format
+	return h.isValidCustomResolution(size)
 }

--- a/internal/api/routes.go
+++ b/internal/api/routes.go
@@ -84,6 +84,14 @@ func (r *Router) setupRoutes() {
 			images.GET("/:id/original", r.imageHandler.DownloadOriginal)
 			images.GET("/:id/thumbnail", r.imageHandler.DownloadThumbnail)
 			images.GET("/:id/preview", r.imageHandler.DownloadPreview)
+
+			// Presigned URL generation (must come before custom resolution to avoid conflicts)
+			images.GET("/:id/original/presigned-url", r.imageHandler.GeneratePresignedURL)
+			images.GET("/:id/thumbnail/presigned-url", r.imageHandler.GeneratePresignedURL)
+			images.GET("/:id/preview/presigned-url", r.imageHandler.GeneratePresignedURL)
+			images.GET("/:id/:resolution/presigned-url", r.imageHandler.GeneratePresignedURL)
+
+			// Custom resolution download (must come last due to wildcard)
 			images.GET("/:id/:resolution", r.imageHandler.DownloadCustomResolution)
 
 			// Optional: Delete image (future feature)

--- a/internal/models/image.go
+++ b/internal/models/image.go
@@ -52,6 +52,13 @@ type InfoResponse struct {
 	CreatedAt            time.Time     `json:"created_at"`
 }
 
+// PresignedURLResponse represents the response for presigned URL endpoint
+type PresignedURLResponse struct {
+	URL       string    `json:"url"`
+	ExpiresAt time.Time `json:"expires_at"`
+	ExpiresIn int       `json:"expires_in"` // seconds
+}
+
 // DimensionInfo represents image dimensions
 type DimensionInfo struct {
 	Width  int `json:"width"`

--- a/internal/service/image.go
+++ b/internal/service/image.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"io"
 	"strings"
+	"time"
 
 	"resizr/internal/config"
 	"resizr/internal/models"
@@ -328,6 +329,31 @@ func (s *ImageServiceImpl) ListImages(ctx context.Context, offset, limit int) ([
 	total := -1
 
 	return images, total, nil
+}
+
+// GeneratePresignedURL generates a pre-signed URL for direct access to storage
+func (s *ImageServiceImpl) GeneratePresignedURL(ctx context.Context, storageKey string, duration time.Duration) (string, error) {
+	logger.DebugWithContext(ctx, "Generating presigned URL",
+		zap.String("storage_key", storageKey),
+		zap.Duration("duration", duration))
+
+	presignedURL, err := s.storage.GeneratePresignedURL(ctx, storageKey, duration)
+	if err != nil {
+		logger.ErrorWithContext(ctx, "Failed to generate presigned URL",
+			zap.String("storage_key", storageKey),
+			zap.Error(err))
+		return "", models.StorageError{
+			Operation: "generate_presigned_url",
+			Backend:   "S3",
+			Reason:    err.Error(),
+		}
+	}
+
+	logger.InfoWithContext(ctx, "Presigned URL generated successfully",
+		zap.String("storage_key", storageKey),
+		zap.Duration("duration", duration))
+
+	return presignedURL, nil
 }
 
 // Helper methods

--- a/internal/service/interfaces.go
+++ b/internal/service/interfaces.go
@@ -3,6 +3,7 @@ package service
 import (
 	"context"
 	"io"
+	"time"
 
 	"resizr/internal/models"
 )
@@ -26,6 +27,9 @@ type ImageService interface {
 
 	// ListImages retrieves paginated list of images
 	ListImages(ctx context.Context, offset, limit int) ([]*models.ImageMetadata, int, error)
+
+	// GeneratePresignedURL generates a pre-signed URL for direct access to storage
+	GeneratePresignedURL(ctx context.Context, storageKey string, duration time.Duration) (string, error)
 }
 
 // HealthService defines the interface for health checking

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -205,6 +205,75 @@ paths:
         '500':
           $ref: '#/components/responses/InternalServerError'
 
+  /api/v1/images/{id}/{resolution}/presigned-url:
+    get:
+      tags:
+        - Images
+      summary: Generate presigned URL
+      description: |
+        Generate a temporary presigned URL for direct access to image files stored in S3.
+        
+        **Features:**
+        - Direct client-side access to S3 without server proxy
+        - Configurable expiration time (default: 1 hour, max: 7 days)
+        - Support for all available image resolutions
+        - Reduces server bandwidth and improves performance
+        - Consistent with existing download endpoint structure
+        
+        **Use Cases:**
+        - Mobile app integration with direct S3 access
+        - Temporary image sharing with expiration
+        - Client-side downloads for large images
+        - CDN integration and caching optimization
+        
+      operationId: generatePresignedURL
+      parameters:
+        - $ref: '#/components/parameters/ImageId'
+        - $ref: '#/components/parameters/Resolution'
+        - name: expires_in
+          in: query
+          required: false
+          description: URL expiration time in seconds (default: 3600, max: 604800)
+          schema:
+            type: integer
+            minimum: 1
+            maximum: 604800
+            default: 3600
+          example: 3600
+      responses:
+        '200':
+          description: Presigned URL generated successfully
+          headers:
+            X-Request-ID:
+              schema:
+                type: string
+                format: uuid
+              description: Unique request identifier for tracing
+            Access-Control-Allow-Origin:
+              schema:
+                type: string
+              description: CORS allowed origin
+            Access-Control-Expose-Headers:
+              schema:
+                type: string
+              description: Headers exposed to the client
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PresignedURLResponse'
+              example:
+                url: "https://bucket.s3.amazonaws.com/images/f47ac10b-58cc-4372-a567-0e02b2c3d479/thumbnail.jpg?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=..."
+                expires_at: "2025-09-12T16:30:00Z"
+                expires_in: 3600
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '429':
+          $ref: '#/components/responses/TooManyRequests'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
+
   /api/v1/images/{id}/original:
     get:
       tags:
@@ -576,6 +645,16 @@ components:
       schema:
         type: string
       example: "bytes=0-1023"
+    
+    Resolution:
+      name: resolution
+      in: path
+      required: true
+      description: Image resolution/size
+      schema:
+        type: string
+        pattern: '^(original|thumbnail|preview|[1-9]\d{0,3}x[1-9]\d{0,3})$'
+      example: "thumbnail"
 
   schemas:
     UploadResponse:
@@ -644,6 +723,28 @@ components:
           format: date-time
           description: Timestamp when the image was uploaded
           example: "2025-09-11T10:30:00Z"
+
+    PresignedURLResponse:
+      type: object
+      required:
+        - url
+        - expires_at
+        - expires_in
+      properties:
+        url:
+          type: string
+          format: uri
+          description: Presigned URL for direct access to the image
+          example: "https://bucket.s3.amazonaws.com/images/f47ac10b-58cc-4372-a567-0e02b2c3d479/thumbnail.jpg?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=..."
+        expires_at:
+          type: string
+          format: date-time
+          description: Timestamp when the presigned URL expires
+          example: "2025-09-12T16:30:00Z"
+        expires_in:
+          type: integer
+          description: URL expiration time in seconds
+          example: 3600
 
     Dimensions:
       type: object


### PR DESCRIPTION
## 🚀 Feature: Presigned URL Generation for Direct S3 Access

  ### **Summary**
  Adds a new RESTful endpoint to generate time-limited presigned URLs for direct client access to image files stored in S3, eliminating the need for server proxy downloads.      

  ### **New Endpoint**
  GET /api/v1/images/{id}/{resolution}/presigned-url?expires_in={seconds}

  ### **Features**
  - ✅ **Consistent API Design** - Follows existing endpoint patterns (`/original`, `/thumbnail`, `/{resolution}`)
  - ✅ **Flexible Expiration** - Configurable duration from 1 second to 7 days (default: 1 hour)
  - ✅ **All Resolutions Supported** - Works with `original`, `thumbnail`, `preview`, and custom resolutions
  - ✅ **Comprehensive Validation** - Input validation, error handling, and security checks