### PR TITLE
Potential fix for code scanning alert no. 1: Incorrect conversion between integer types

### DIFF
--- a/internal/repository/redis.go
+++ b/internal/repository/redis.go
@@ -409,11 +409,8 @@ func (r *RedisRepository) DeleteCache(ctx context.Context, key string) error {
 // GetStats retrieves repository statistics
 /// safeInt64ToInt converts int64 to int safely, returning 0 if out of bounds.
 func safeInt64ToInt(v int64) int {
-	// On 32-bit platforms, int is 32 bits; on 64-bit, it's 64.
-	// Set bounds based on this.
-	const minInt = int64(int(^uint(0)>>1)) * -1 - 1 // matches int's min value
-	const maxInt = int64(int(^uint(0)>>1))
-	if v < minInt || v > maxInt {
+	// Use math.MinInt and math.MaxInt for portability/platform-safety
+	if v < math.MinInt || v > math.MaxInt {
 		return 0 // or set to -1 to signal "invalid"
 	}
 	return int(v)


### PR DESCRIPTION
Potential fix for [https://github.com/K0lin/Resizr/security/code-scanning/1](https://github.com/K0lin/Resizr/security/code-scanning/1)

The best fix is to ensure that the value parsed by `parseInfoValue` is validated before conversion to the smaller `int` type. Before converting from `int64` to `int`, check that the output value is within the bounds of the `int` type for the current platform. In Go, `int` is either 32 or 64 bits depending on the platform, so you must check both upper and lower bounds using the constants in the `math` package (`math.MaxInt32`, `math.MinInt32`, `math.MaxInt64`, `math.MinInt64`). For portability and safety, it's best to perform this check at the point where you convert the value, i.e., before/at line 429. This can be achieved by introducing a helper function such as `safeInt64ToInt`, which performs the check and provides a fallback value (e.g., 0 or -1) if the bounds are exceeded.

To implement this:
- Add an import for `math` for the max/min constants.
- Add a helper function, e.g., `safeInt64ToInt(v int64) int`, to perform the bounds check based on platform.
- Replace the direct conversion (`int(...)`) in line 429 with a call to this helper.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
